### PR TITLE
Redesign dictionary: use Vector{DictSlot{K,V}}

### DIFF
--- a/benchmark/ConcurrentCollectionsBenchmarks/src/bench_dict_migration.jl
+++ b/benchmark/ConcurrentCollectionsBenchmarks/src/bench_dict_migration.jl
@@ -3,7 +3,7 @@ module BenchDictMigration
 using BenchmarkTools
 using ConcurrentCollections
 using ConcurrentCollections.Implementations:
-    LINEAR_PROBING_DICT_EXPAND_BASESIZE, migrate_serial!, new_slots_and_pairnodes
+    LINEAR_PROBING_DICT_EXPAND_BASESIZE, migrate_serial!
 
 pad16(x) = string(x; pad = 16)
 
@@ -28,13 +28,11 @@ function setup(; generate_options...)
     for key in keys(CACHE[])
         CacheType = typeof(CACHE[][key])
         suite[key] = @benchmarkable(
-            migrate_serial!(newslots, newpairnodes, slots, pairnodes),
+            migrate_serial!(newslots, slots),
             setup = begin
                 dict = CACHE[][$key]::$CacheType
                 slots = copy(dict.slots)
-                pairnodes = copy(dict.pairnodes)
-                newslots, newpairnodes =
-                    new_slots_and_pairnodes(slots, pairnodes, true)
+                newslots = similar(slots, length(slots) * 2)
             end,
             evals = 1,
         )

--- a/src/ConcurrentCollections.jl
+++ b/src/ConcurrentCollections.jl
@@ -63,6 +63,7 @@ using .UnsafeAtomics: acq_rel, acquire, monotonic, release, seq_cst, unordered
 include("utils.jl")
 include("cache.jl")
 include("atomicsutils.jl")
+include("promise.jl")
 include("dict.jl")
 include("workstealing.jl")
 include("msqueue.jl")

--- a/src/promise.jl
+++ b/src/promise.jl
@@ -1,0 +1,49 @@
+mutable struct Promise{T,S>:Union{Nothing,Some{T}}}
+    @atomic value::S
+    notify::Threads.Condition
+    # TODO: just use a stack of Tasks?
+
+    function Promise{T}() where {T}
+        if sizeof(Some{Union{Nothing,Some{T}}}) > sizeof(UInt64)
+            return new{T,Any}(nothing, Threads.Condition())
+        else
+            return new{T,Union{Nothing,Some{T}}}(nothing, Threads.Condition())
+        end
+    end
+end
+
+Promise() = Promise{Any}()
+
+function tryput!(p::Promise{T}, value) where {T}
+    new = Some{T}(value)
+    old, ok = @atomicreplace p.value nothing => new
+    if ok
+        lock(p.notify) do
+            notify(p.notify)
+        end
+    end
+    return old
+end
+
+function Base.put!(p::Promise{T}, value) where {T}
+    if tryput!(p, value) !== nothing
+        error("Promise already has a value")
+    end
+    return p
+end
+
+function Base.fetch(p::Promise{T}) where {T}
+    value = @atomic p.value
+    if value isa Some{T}
+        return something(value)
+    end
+    lock(p.notify) do
+        while true
+            local value = @atomic p.value
+            if value isa Some{T}
+                return something(value)
+            end
+            wait(p.notify)
+        end
+    end
+end

--- a/test/ConcurrentCollectionsTests/src/test_dict.jl
+++ b/test/ConcurrentCollectionsTests/src/test_dict.jl
@@ -1,53 +1,8 @@
 module TestDict
 
 using ConcurrentCollections
-using ConcurrentCollections.Implementations:
-    LPDKeyState,
-    LPD_BITMASK,
-    LPD_DELETED,
-    LPD_EMPTY,
-    LPD_HASKEY,
-    LPD_MOVED,
-    LPD_MOVED_EMPTY,
-    LPD_NBITS,
-    KeyInfo,
-    clusters,
-    migrate!,
-    setdata,
-    setstate
+using ConcurrentCollections.Implementations: clusters, migrate!
 using Test
-
-function test_keyinfo()
-    @test KeyInfo(UInt64(0)).state === LPD_EMPTY
-    @testset for state in instances(LPDKeyState)
-        @test KeyInfo{UInt64}(state, 0x0123456789abcdef).state === state
-        if state !== LPD_EMPTY
-            @test KeyInfo{UInt64}(state, 0x0123456789abcdef).keydata === 0x0123456789abcdef
-        end
-        @test setstate(KeyInfo(rand(UInt64)), state).state === state
-        keydata = rand(UInt64) >> LPD_NBITS
-        @test setdata(KeyInfo(rand(UInt64)), keydata).keydata === keydata
-    end
-end
-
-function test_keyinfo_properties()
-    keyinfo = KeyInfo{UInt64}(rand(UInt64))
-    enum_to_property = Dict(
-        LPD_EMPTY => :isempty,
-        LPD_DELETED => :isdeleted,
-        LPD_MOVED_EMPTY => :ismovedempty,
-        LPD_MOVED => :ismoved,
-        LPD_HASKEY => :haskey,
-    )
-    properties = collect(values(enum_to_property))
-    @testset for state in instances(LPDKeyState), prop in properties
-        if enum_to_property[state] === prop
-            @test getproperty(setstate(keyinfo, state), prop)
-        else
-            @test !getproperty(setstate(keyinfo, state), prop)
-        end
-    end
-end
 
 function test_expand_and_shrink(n = 17)
     d = ConcurrentDict{Int,Int}()


### PR DESCRIPTION
Since Julia does not have atomics for arrays, supporting boxed Julia objects in a hash table requires indirection (i.e., a `mutable struct`) *somewhere* at the moment because no atomic operation can be defined on `Vector{Any}`. Previously, `LinearProbingDict` was using a `mutable struct` only for "storage" and the actual linearization was done on a dense array using 128 bit CAS (based on Maier et al. (2019)). However, it required complex key/value storage management to actually store objects in the hash table. It turned out that just using `Vector{DictSlot{K,V}}` (where `DictSlot{K,V}` is a `mutable struct`) is more straightforward and beneficial in terms of performance. The important optimization to make it practical is to avoid copying `DictSlot{K,V}` during migration.

A nice side-effect of this approach is that it gets rid of the "torn" 64-bit load which is not likely to be supported in Julia. It is now possible to separate key and value to distinct `Vector`s if atomics on `Vector{Any}` is supported at some point. This is more likely to be supported than updating key/value location directly in `Vector{Pair{Any,Any}}`.
